### PR TITLE
tweak: fix next frame lang support

### DIFF
--- a/web/src/hooks/use-keyboard-listener.tsx
+++ b/web/src/hooks/use-keyboard-listener.tsx
@@ -7,6 +7,36 @@ export type KeyModifiers = {
   shift: boolean;
 };
 
+// Map key codes to expected key names for letter keys
+const KEY_CODE_MAP: Record<string, string> = {
+  KeyA: "a",
+  KeyB: "b",
+  KeyC: "c",
+  KeyD: "d",
+  KeyE: "e",
+  KeyF: "f",
+  KeyG: "g",
+  KeyH: "h",
+  KeyI: "i",
+  KeyJ: "j",
+  KeyK: "k",
+  KeyL: "l",
+  KeyM: "m",
+  KeyN: "n",
+  KeyO: "o",
+  KeyP: "p",
+  KeyQ: "q",
+  KeyR: "r",
+  KeyS: "s",
+  KeyT: "t",
+  KeyU: "u",
+  KeyV: "v",
+  KeyW: "w",
+  KeyX: "x",
+  KeyY: "y",
+  KeyZ: "z",
+};
+
 export default function useKeyboardListener(
   keys: string[],
   listener: (key: string | null, modifiers: KeyModifiers) => void,
@@ -26,9 +56,13 @@ export default function useKeyboardListener(
         shift: e.shiftKey,
       };
 
-      if (keys.includes(e.key)) {
+      // For letter keys, use the key code mapping to support different keyboard layouts
+      // For special keys, use e.key as before
+      const keyToCheck = KEY_CODE_MAP[e.code] || e.key;
+
+      if (keys.includes(keyToCheck)) {
         if (preventDefault) e.preventDefault();
-        listener(e.key, modifiers);
+        listener(keyToCheck, modifiers);
       } else if (e.key === "Shift" || e.key === "Control" || e.key === "Meta") {
         listener(null, modifiers);
       }
@@ -49,9 +83,13 @@ export default function useKeyboardListener(
         shift: false,
       };
 
-      if (keys.includes(e.key)) {
+      // For letter keys, use the key code mapping to support different keyboard layouts
+      // For special keys, use e.key as before
+      const keyToCheck = KEY_CODE_MAP[e.code] || e.key;
+
+      if (keys.includes(keyToCheck)) {
         e.preventDefault();
-        listener(e.key, modifiers);
+        listener(keyToCheck, modifiers);
       } else if (e.key === "Shift" || e.key === "Control" || e.key === "Meta") {
         listener(null, modifiers);
       }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix keyboard listener to support different keyboard layouts

- Add key code mapping for letter keys (A-Z)

- Replace `e.key` with `e.code` mapping for internationalization


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Keyboard Event"] --> B["Key Code Mapping"]
  B --> C["Check Against Expected Keys"]
  C --> D["Trigger Listener"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-keyboard-listener.tsx</strong><dd><code>Add international keyboard layout support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/hooks/use-keyboard-listener.tsx

<li>Add <code>KEY_CODE_MAP</code> constant mapping key codes to letter keys<br> <li> Replace <code>e.key</code> with mapped key code for letter key detection<br> <li> Support international keyboard layouts by using <code>e.code</code><br> <li> Maintain backward compatibility for special keys


</details>


  </td>
  <td><a href="https://github.com/skylineagle/caesar/pull/17/files#diff-8a6ecbb7c513a8100855611e7bd364d0f4f7b7346dfb146f93f8331ba2c84e3d">+42/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>