### PR TITLE
tweak: minor enhancments

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,17 +8,17 @@ import { Suspense, lazy, useEffect } from "react";
 import { isDesktop, isMobile } from "react-device-detect";
 import {
   BrowserRouter,
+  Outlet,
   Route,
   Routes,
   useNavigate,
-  Outlet,
 } from "react-router-dom";
+import { Toaster } from "sonner";
 import Statusbar from "./components/Statusbar";
 import Bottombar from "./components/navigation/Bottombar";
 import { Redirect } from "./components/navigation/Redirect";
 import { cn } from "./lib/utils";
 import { isPWA } from "./utils/isPWA";
-import { Toaster } from "sonner";
 
 const Live = lazy(() => import("@/pages/Live"));
 const GroupView = lazy(() => import("@/pages/GroupView"));

--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -344,7 +344,7 @@ export default function LivePlayer({
         iOSCompatFullScreen={iOSCompatFullScreen}
         onPlaying={playerIsPlaying}
         pip={pip}
-        // onError={onError}
+        onError={onError}
       />
     );
   } else if (preferredLiveMode == "mse") {

--- a/web/src/context/language-provider.tsx
+++ b/web/src/context/language-provider.tsx
@@ -54,9 +54,11 @@ export function LanguageProvider({
       if (i18next.isInitialized) {
         i18next.changeLanguage(newLanguage);
       } else {
-        i18next.on("initialized", () => {
+        const onInit = () => {
           i18next.changeLanguage(newLanguage);
-        });
+          i18next.off("initialized", onInit);
+        };
+        i18next.on("initialized", onInit);
       }
 
       return newLanguage;
@@ -75,11 +77,18 @@ export function LanguageProvider({
 
     if (i18next.isInitialized) {
       i18next.changeLanguage(language);
-    } else {
-      i18next.on("initialized", () => {
-        i18next.changeLanguage(language);
-      });
+      return;
     }
+
+    const onInit = () => {
+      i18next.changeLanguage(language);
+      i18next.off("initialized", onInit);
+    };
+    i18next.on("initialized", onInit);
+
+    return () => {
+      i18next.off("initialized", onInit);
+    };
   }, [language, systemLanguage]);
 
   const value = {

--- a/web/src/context/language-provider.tsx
+++ b/web/src/context/language-provider.tsx
@@ -50,7 +50,15 @@ export function LanguageProvider({
     try {
       const storedData = localStorage.getItem(storageKey);
       const newLanguage = storedData || systemLanguage;
-      i18next.changeLanguage(newLanguage);
+
+      if (i18next.isInitialized) {
+        i18next.changeLanguage(newLanguage);
+      } else {
+        i18next.on("initialized", () => {
+          i18next.changeLanguage(newLanguage);
+        });
+      }
+
       return newLanguage;
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -64,14 +72,21 @@ export function LanguageProvider({
     document.documentElement.lang = language;
 
     if (language === systemLanguage) return;
-    i18next.changeLanguage(language);
+
+    if (i18next.isInitialized) {
+      i18next.changeLanguage(language);
+    } else {
+      i18next.on("initialized", () => {
+        i18next.changeLanguage(language);
+      });
+    }
   }, [language, systemLanguage]);
 
   const value = {
     language,
-    setLanguage: (language: string) => {
-      localStorage.setItem(storageKey, language);
-      setLanguage(language);
+    setLanguage: (newLanguage: string) => {
+      localStorage.setItem(storageKey, newLanguage);
+      setLanguage(newLanguage);
       window.location.reload();
     },
   };

--- a/web/src/utils/i18n.ts
+++ b/web/src/utils/i18n.ts
@@ -33,7 +33,8 @@ i18n
       "views/settings",
       "views/system",
       "views/exports",
-      "views/explore",
+      "views/configEditor",
+      "views/faceLibrary",
     ],
     defaultNS: "common",
 

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -268,7 +268,7 @@ export default function LiveCameraView({
       return "webrtc";
     }
 
-    if (webRTC && isRestreamed) {
+    if (isRestreamed) {
       return "webrtc";
     }
 
@@ -403,19 +403,20 @@ export default function LiveCameraView({
   const handleError = useCallback(
     (e: LivePlayerError) => {
       if (e) {
-        if (
-          !webRTC &&
-          config &&
-          config.go2rtc?.webrtc?.candidates?.length > 0
-        ) {
+        if (e === "mse-decode") {
           setWebRTC(true);
+        } else if (isRestreamed) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `LiveCameraView: WebRTC failed for ${camera.name}, but keeping WebRTC for retry`,
+          );
         } else {
           setWebRTC(false);
           setLowBandwidth(true);
         }
       }
     },
-    [config, webRTC],
+    [isRestreamed, camera.name],
   );
 
   return (

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -240,8 +240,15 @@ export default function LiveDashboardView({
     (cameraName: string, error: LivePlayerError) => {
       setPreferredLiveModes((prevModes) => {
         const newModes = { ...prevModes };
+        const currentMode = prevModes[cameraName];
+
         if (error === "mse-decode") {
           newModes[cameraName] = "webrtc";
+        } else if (currentMode === "webrtc") {
+          // eslint-disable-next-line no-console
+          console.log(
+            `LiveDashboard: WebRTC failed for ${cameraName}, but keeping WebRTC for retry`,
+          );
         } else {
           newModes[cameraName] = "jsmpeg";
         }


### PR DESCRIPTION
### **User description**
i18n fixes
webrtc player stabillity


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix i18n initialization race conditions

- Improve WebRTC player error handling

- Update namespace configurations

- Enhance live streaming stability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["i18n Provider"] --> B["Language Change"]
  B --> C["Initialization Check"]
  D["WebRTC Player"] --> E["Error Handling"]
  E --> F["Retry Logic"]
  G["Live Views"] --> H["Stream Mode Selection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>i18n.ts</strong><dd><code>Update i18n namespace configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/utils/i18n.ts

<ul><li>Remove duplicate <code>views/explore</code> namespace<br> <li> Add <code>views/configEditor</code> and <code>views/faceLibrary</code> namespaces</ul>


</details>


  </td>
  <td><a href="https://github.com/skylineagle/caesar/pull/41/files#diff-b86dfa196026c60adc127b84e168d6ce8fcdbcc0982f693a2422bf94096e47cb">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Reorganize import statements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/App.tsx

<ul><li>Reorder imports for better organization<br> <li> Move <code>Outlet</code> and <code>Toaster</code> imports to proper positions</ul>


</details>


  </td>
  <td><a href="https://github.com/skylineagle/caesar/pull/41/files#diff-2e5aec0d80c33c218d97cb48edb61724a5e25bfc33478de5907916a90a92accf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LivePlayer.tsx</strong><dd><code>Enable WebRTC player error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/player/LivePlayer.tsx

- Re-enable `onError` callback for WebRTC player


</details>


  </td>
  <td><a href="https://github.com/skylineagle/caesar/pull/41/files#diff-cf8202178797daf2fd3f9b5849baf8cb49233e50c6aa02faa05011525c9f355a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>language-provider.tsx</strong><dd><code>Fix i18n initialization race conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/context/language-provider.tsx

<ul><li>Add i18next initialization checks before language changes<br> <li> Use event listener for uninitialized i18next instances<br> <li> Fix parameter naming in <code>setLanguage</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/skylineagle/caesar/pull/41/files#diff-b1f4cd406c6395e2571ddee422a2f1dc5ca7d4f86273fe9fd7c3e9994d39fb9e">+20/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LiveCameraView.tsx</strong><dd><code>Enhance live camera WebRTC handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/live/LiveCameraView.tsx

<ul><li>Simplify WebRTC mode selection logic for restreamed cameras<br> <li> Improve error handling with specific retry logic<br> <li> Add console logging for WebRTC failures</ul>


</details>


  </td>
  <td><a href="https://github.com/skylineagle/caesar/pull/41/files#diff-ac64fed2fdcba65c61771a003277d055f2c857aecda8f62b8d5e1db5e82940b3">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LiveDashboardView.tsx</strong><dd><code>Improve dashboard WebRTC error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/views/live/LiveDashboardView.tsx

<ul><li>Add WebRTC retry logic for failed connections<br> <li> Include console logging for debugging failures<br> <li> Improve error handling flow</ul>


</details>


  </td>
  <td><a href="https://github.com/skylineagle/caesar/pull/41/files#diff-e1bd5b301a0404a430daeb25ca4acaa5a47c437dfbfcefe7ccd19db1bc6e84b9">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

