### PR TITLE
fix: prod proxy fixes for webRTC

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -234,6 +234,64 @@ http {
             }
             proxy_pass http://go2rtc/api/webrtc;
             include proxy.conf;
+
+            # WebRTC specific headers
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Disable caching for WebRTC
+            proxy_cache off;
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate";
+            expires off;
+
+            # Increase timeouts for WebRTC
+            proxy_read_timeout 300;
+            proxy_send_timeout 300;
+            proxy_connect_timeout 300;
+        }
+
+        # WebRTC API endpoint for configuration
+        location /api/go2rtc/api {
+            include auth_request.conf;
+            limit_except GET {
+                deny  all;
+            }
+            proxy_pass http://go2rtc/api;
+            include proxy.conf;
+
+            # WebRTC specific headers
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Disable caching for WebRTC
+            proxy_cache off;
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate";
+            expires off;
+        }
+
+        # WebRTC WebSocket endpoint (for fallback)
+        location /api/go2rtc/ws {
+            include auth_request.conf;
+            proxy_pass http://go2rtc/api/ws;
+            include proxy.conf;
+
+            # WebSocket support
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Disable caching for WebRTC
+            proxy_cache off;
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate";
+            expires off;
         }
 
         location ~* /api/.*\.(jpg|jpeg|png|webp|gif)$ {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Enhanced WebRTC proxy configuration with proper headers

- Added new API and WebSocket endpoints for go2rtc

- Implemented caching controls and timeout settings

- Fixed WebSocket upgrade handling for real-time communication


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Existing /api/go2rtc/webrtc"] --> B["Enhanced with headers & timeouts"]
  C["New /api/go2rtc/api endpoint"] --> D["GET requests with caching disabled"]
  E["New /api/go2rtc/ws endpoint"] --> F["WebSocket support with upgrade headers"]
  B --> G["WebRTC Communication"]
  D --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nginx.conf</strong><dd><code>Enhanced WebRTC proxy configuration with new endpoints</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/main/rootfs/usr/local/nginx/conf/nginx.conf

<ul><li>Enhanced existing <code>/api/go2rtc/webrtc</code> endpoint with WebRTC-specific <br>headers and timeouts<br> <li> Added new <code>/api/go2rtc/api</code> endpoint for GET requests with caching <br>disabled<br> <li> Added new <code>/api/go2rtc/ws</code> WebSocket endpoint with proper upgrade <br>headers<br> <li> Implemented consistent caching controls across all WebRTC endpoints</ul>


</details>


  </td>
  <td><a href="https://github.com/skylineagle/caesar/pull/50/files#diff-bff60ae2e26f21d7ae405c36fd8737743e953e4f9c4f2824dfbfe5a8fc30087f">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

